### PR TITLE
Add annotations so we can publish wit-bindgen to WAPM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "wit-bindgen-cli"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
+description = "Generate glue code for *.wit files"
 
 [workspace]
 members = [
@@ -34,3 +35,10 @@ wit-bindgen-gen-wasmer-py = { path = 'crates/gen-wasmer-py', features = ['struct
 [profile.dev.package.cranelift-codegen]
 debug-assertions = false
 opt-level = 2
+
+[package.metadata.wapm]
+namespace = "Michael-F-Bryan"
+abi = "wasi"
+
+[package.metadata.wapm.fs]
+"."="."


### PR DESCRIPTION
This lets us use [`cargo-wapm`](https://github.com/Michael-F-Bryan/cargo-wapm) to publish the `wit-bindgen` CLI to WAPM.

@ayys, if you want to publish your own version you'll need to change the namespace in `Cargo.toml` from `Michael-F-Bryan` to your own user and run `cargo wapm` to build+publish to the current registry.