### PR TITLE
Add an option to always generate types, regardless of whether they are used

### DIFF
--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -55,6 +55,10 @@ pub struct Opts {
     /// crate.
     #[cfg_attr(feature = "structopt", structopt(skip))]
     pub standalone: bool,
+
+    /// Generate type definitions, even if they are never used.
+    #[cfg_attr(feature = "structopt", structopt(long))]
+    pub force_generate_structs: bool,
 }
 
 #[derive(Default)]
@@ -90,6 +94,10 @@ impl RustWasm {
 }
 
 impl RustGenerator for RustWasm {
+    fn always_generate_structs(&self) -> bool {
+        self.opts.force_generate_structs
+    }
+
     fn default_param_mode(&self) -> TypeMode {
         if self.in_import {
             // We default to borrowing as much as possible to maximize the ability

--- a/crates/gen-rust/src/lib.rs
+++ b/crates/gen-rust/src/lib.rs
@@ -32,6 +32,12 @@ pub trait RustGenerator {
         false
     }
 
+    /// Make the code generator always generate types, even if they are never
+    /// used.
+    fn always_generate_structs(&self) -> bool {
+        false
+    }
+
     fn rustdoc(&mut self, docs: &Docs) {
         let docs = match &docs.contents {
             Some(docs) => docs,
@@ -382,10 +388,12 @@ pub trait RustGenerator {
     fn modes_of(&self, iface: &Interface, ty: TypeId) -> Vec<(String, TypeMode)> {
         let info = self.info(ty);
         let mut result = Vec::new();
-        if info.param {
+        if info.param || self.always_generate_structs() {
             result.push((self.param_name(iface, ty), self.default_param_mode()));
         }
-        if info.result && (!info.param || self.uses_two_names(&info)) {
+        if info.result
+            && (!info.param || self.always_generate_structs() || self.uses_two_names(&info))
+        {
             result.push((self.result_name(iface, ty), TypeMode::Owned));
         }
         result


### PR DESCRIPTION
This supercedes commit fbea20fecaaa280841d35fcc5962f1ead572cfc4 from #19.

We originally needed to add this with https://github.com/wasmerio/wasmer/commit/fbdec22bfc493849e9d194afe7999764f74d3f7e because some WASI types weren't being generated if our WASI functions didn't use them.