### PR TITLE
Adds flags to enable the use of wai-bindgen-wasmer in JS context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2499,6 +2499,7 @@ dependencies = [
  "wasmer-derive",
  "wasmer-types",
  "wasmer-vm",
+ "wasmparser 0.83.0",
  "wat",
  "winapi",
 ]

--- a/crates/wasmer/Cargo.toml
+++ b/crates/wasmer/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+
 [dependencies]
 anyhow = "1.0"
 async-trait = { version = "0.1.50", optional = true }
@@ -18,9 +19,18 @@ once_cell = "1.13"
 thiserror = "1.0"
 tracing-lib = { version = "0.1.26", optional = true, package = "tracing" }
 wai-bindgen-wasmer-impl = { path = "../wasmer-impl", version = "0.2.2" }
-wasmer = "3.0.0-rc.1"
+wasmer = {version = "3.0.0-rc.1", default-features=false}
 
 [features]
+default=["sys"]
+# Use this if the bindings are being used in an a program that isn't itself 
+# being compiled to wasm
+sys =["wasmer/sys-default"]
+
+# Use this if the bindings are being used in an a program that is itself 
+# being compiled to wasm
+js = ["wasmer/js-default"]
+
 # Enables generated code to emit events via the `tracing` crate whenever wasm is
 # entered and when native functions are called. Note that tracin is currently
 # only done for imported functions.

--- a/crates/wasmer/Cargo.toml
+++ b/crates/wasmer/Cargo.toml
@@ -19,7 +19,7 @@ once_cell = "1.13"
 thiserror = "1.0"
 tracing-lib = { version = "0.1.26", optional = true, package = "tracing" }
 wai-bindgen-wasmer-impl = { path = "../wasmer-impl", version = "0.2.2" }
-wasmer = {version = "3.0.0-rc.1", default-features=false}
+wasmer = {version = "3.0.0", default-features=false}
 
 [features]
 default=["sys"]


### PR DESCRIPTION
This should resolve #28 I think. 

When using wai-bindgen-wasmer in a host that is going to be compiled to wasm, the feature flag "js" can be used, otherwise this defaults to sys. For example a host with the  Cargo.toml 

```toml
[package]
name = "host"
version = "0.1.0"
edition = "2021"

# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

[features]
default =["sys"]
js = ["wai-bindgen-wasmer/js", "wasmer/js-default"]
sys  = ["wai-bindgen-wasmer/sys", "wasmer/sys-default"]

[dependencies]
wai-bindgen-wasmer = {version = "0.2.2", default-features = false }
wasmer = {version = "3.0.0-rc.1", default-features = false}
```

Can be compiled to run as standard with 

```bash
cargo run
```

and compiled to a wasm module using 

```bash
cargo build --target wasm32-unknown-unknown --no-default-features --features js 
```

This seems to work for the example I need it for but not 100% sure if this is sufficient in general. Also not sure if there is a good way to add a test for this.

Happy to expand on this PR if I am missing things